### PR TITLE
Implement get single team feature

### DIFF
--- a/src/routes/controllers/team.js
+++ b/src/routes/controllers/team.js
@@ -77,3 +77,18 @@ export const update = async (req, res) => {
     return helpers.serverError(res, error.message);
   }
 };
+
+export const find = async (req, res) => {
+  const { teamId } = req.params;
+
+  try {
+    const team = await Team.findOne({ _id: teamId });
+    if (!team) {
+      return helpers.errorResponse(res, 404, 'This team does not exist');
+    }
+    return helpers.successResponse(res, 200, 'Team found', team);
+  } catch (error) {
+    /* istanbul ignore next */
+    return helpers.serverError(res, error.message);
+  }
+};

--- a/src/routes/team.js
+++ b/src/routes/team.js
@@ -31,4 +31,11 @@ router.patch(
   actions.update,
 );
 
+router.get(
+  '/:teamId',
+  validateRequest(objectIdSchema, 'params'),
+  checkTokenValidity,
+  actions.find,
+);
+
 export default router;

--- a/src/tests/e2e/team.test.js
+++ b/src/tests/e2e/team.test.js
@@ -207,3 +207,40 @@ describe('E2E Team Update', () => {
     expect(res.status).toBe(422);
   });
 });
+
+describe('E2E Fetch a single team', () => {
+  let team;
+  it('should throw an error when a token is not present in the request header', async () => {
+    team = await Team.findOne();
+    const res = await request(app).get(`${teamsUrl}/${team._id}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('Unauthorized user, please login');
+  });
+
+  it('should fetch a team successfully', async () => {
+    const res = await request(app)
+      .get(`${teamsUrl}/${team._id}`)
+      .set('authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.name).toBe(team.name);
+  });
+
+  it('should return a 404 response when the team cannot be found', async () => {
+    const res = await request(app)
+      .get(`${teamsUrl}/5e1b70de48bd99411c09389e`)
+      .set('authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe('This team does not exist');
+  });
+
+  it('should return a 422 response when the teamId passed is not a valid mongodb objectId', async () => {
+    const res = await request(app)
+      .get(`${teamsUrl}/5e1b70de48bd99411c09389e---`)
+      .set('authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(422);
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Implement get single team feature
#### Description of Task to be completed?
- [x] create route action for fetching a single tem
- [x] create validators for route
- [x] write unit tests for the endpoint
#### How should this be manually tested?
- checkout to this branch
- get a team from your database
- make a `GET` request to the endpoint `/api/v1/teams/team-id-from-your-database` and set your token in the request header. For a valid token, you can signup via `api/v1/auth/signup` if you haven't, then use your token
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?(if applicable)
N/A
#### Screenshots
N/A