### PR TITLE
Implement delete single team feature

### DIFF
--- a/src/routes/controllers/team.js
+++ b/src/routes/controllers/team.js
@@ -92,3 +92,23 @@ export const find = async (req, res) => {
     return helpers.serverError(res, error.message);
   }
 };
+
+export const deleteOne = async (req, res) => {
+  const { teamId } = req.params;
+
+  try {
+    const team = await Team.findOne({ _id: teamId });
+    if (!team) {
+      return helpers.errorResponse(res, 404, 'This team does not exist');
+    }
+    const deletedTeam = await Team.findByIdAndDelete({ _id: teamId });
+    if (deletedTeam) {
+      return helpers.successResponse(res, 200, 'Team Deleted');
+    }
+    /* istanbul ignore next */
+    throw Error('What could ever happen here anyways?');
+  } catch (error) {
+    /* istanbul ignore next */
+    return helpers.serverError(res, error.message);
+  }
+};

--- a/src/routes/team.js
+++ b/src/routes/team.js
@@ -38,4 +38,12 @@ router.get(
   actions.find,
 );
 
+router.delete(
+  '/:teamId',
+  validateRequest(objectIdSchema, 'params'),
+  checkTokenValidity,
+  verifyAdminUser,
+  actions.deleteOne,
+);
+
 export default router;

--- a/src/tests/e2e/team.test.js
+++ b/src/tests/e2e/team.test.js
@@ -244,3 +244,50 @@ describe('E2E Fetch a single team', () => {
     expect(res.status).toBe(422);
   });
 });
+
+describe('E2E Delete a team', () => {
+  let team;
+  it('should throw an error when a token is not present in the request header', async () => {
+    team = await Team.findOne();
+    const res = await request(app).delete(`${teamsUrl}/${team._id}`);
+
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('Unauthorized user, please login');
+  });
+
+  it('should delete a team successfully', async () => {
+    const res = await request(app)
+      .delete(`${teamsUrl}/${team._id}`)
+      .set('authorization', `Bearer ${adminToken}`);
+
+    console.log(res.body);
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Team Deleted');
+  });
+
+  it('should return a 403 response if the user does not have admin privileges', async () => {
+    const res = await request(app)
+      .delete(`${teamsUrl}/${team._id}`)
+      .set('authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('should return a 404 response when the team cannot be found', async () => {
+    const res = await request(app)
+      .delete(`${teamsUrl}/5e1b70de48bd99411c09389e`)
+      .set('authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe('This team does not exist');
+  });
+
+  it('should return a 422 response when the teamId passed is not a valid mongodb objectId', async () => {
+    const res = await request(app)
+      .delete(`${teamsUrl}/5e1b70de48bd99411c09389e---`)
+      .set('authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(422);
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Implement delete single team feature
#### Description of Task to be completed?
- [x] create route action for team deletion
- [x] create validators for route
- [x] write unit tests for the endpoint
#### How should this be manually tested?
- checkout to this branch
- get a team from your database; preferably one that you detest :laugh
- make a `DELETE` request to the endpoint `/api/v1/teams/team-id-from-your-database` and set your token in the request header. For a valid token, you can signup via `api/v1/auth/signup` if you haven't, then use your token
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?(if applicable)
N/A
#### Screenshots
N/A