### PR TITLE
Admin users can create new fixtures

### DIFF
--- a/src/db/models/Fixture.js
+++ b/src/db/models/Fixture.js
@@ -1,5 +1,8 @@
 import mongoose from 'mongoose';
 
+import Team from './Team';
+import User from './User';
+
 const Schema = mongoose.Schema;
 
 // Describe the schema
@@ -10,12 +13,14 @@ const fixtureSchema = new Schema(
       required: true,
     },
     homeTeamId: {
-      type: String,
+      type: Schema.Types.Mixed,
       required: true,
+      ref: Team,
     },
     awayTeamId: {
-      type: String,
+      type: Schema.Types.Mixed,
       required: true,
+      ref: Team,
     },
     referee: {
       type: String,
@@ -25,6 +30,8 @@ const fixtureSchema = new Schema(
       type: String,
       required: true,
       default: 'PENDING',
+      uppercase: true,
+      enum: ['PENDING', 'PLAYED', 'CANCELLED', 'POSTPONED'],
     },
     uniqueLink: {
       type: String,
@@ -34,6 +41,7 @@ const fixtureSchema = new Schema(
     createdBy: {
       type: String,
       required: true,
+      ref: User,
     },
   },
   { timestamps: { createdAt: 'created_at', updatedAt: 'updated_at' } },

--- a/src/routes/controllers/fixture.js
+++ b/src/routes/controllers/fixture.js
@@ -1,0 +1,62 @@
+import Fixture from '../../db/models/Fixture';
+
+import * as helpers from '../../utils/helpers';
+
+export const create = async (req, res) => {
+  const { date, homeTeamId, awayTeamId } = req.body;
+  const { _id: userId } = req.user;
+
+  try {
+    const existingFixture = await helpers.checkIfFixtureExists({
+      date,
+      homeTeamId,
+      awayTeamId,
+    });
+
+    if (existingFixture) {
+      return helpers.errorResponse(res, 409, 'This Fixture exists already');
+    }
+
+    const [homeTeam] = await helpers.checkIfTeamExists({ _id: homeTeamId });
+    const [awayTeam] = await helpers.checkIfTeamExists({ _id: awayTeamId });
+    if (!homeTeam) {
+      return helpers.errorResponse(
+        res,
+        404,
+        `This team ${homeTeamId} cannot be found`,
+      );
+    }
+    if (!awayTeam) {
+      return helpers.errorResponse(
+        res,
+        404,
+        `This team ${awayTeamId} cannot be found`,
+      );
+    }
+
+    // strip all spaces in between the words
+    const homeTeamName = helpers.stripAllSpaces(homeTeam.name);
+    const awayTeamName = helpers.stripAllSpaces(awayTeam.name);
+    const fixtureLink = `${homeTeamName}-vs-${awayTeamName}-${Math.random()
+      .toString()
+      .replace('.', '')}`;
+
+    const newFixture = await Fixture.create({
+      ...req.body,
+      createdBy: userId,
+      uniqueLink: fixtureLink,
+    });
+
+    return helpers.successResponse(res, 201, 'Fixture created successfully', {
+      date: new Date(newFixture.date).toUTCString(),
+      stadium: homeTeam.stadium,
+      referee: newFixture.referee,
+      homeTeam: homeTeam.name,
+      awayTeam: awayTeam.name,
+      uniqueLink: newFixture.uniqueLink,
+    });
+  } catch (error) {
+    /* istanbul ignore next */
+    return helpers.serverError(res, error.message);
+  }
+};

--- a/src/routes/controllers/team.js
+++ b/src/routes/controllers/team.js
@@ -14,6 +14,7 @@ export const create = async (req, res) => {
     const newTeam = await Team.create(req.body);
 
     return helpers.successResponse(res, 201, 'Team created successfully', {
+      id: newTeam._id,
       name: newTeam.name,
       stadium: newTeam.stadium,
       manager: newTeam.manager,

--- a/src/routes/fixture.js
+++ b/src/routes/fixture.js
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+
+import * as actions from './controllers/fixture';
+import validateRequest from './middlewares/validate-input';
+import { createFixtureSchema } from './middlewares/joi-schema';
+import { checkTokenValidity } from './middlewares/checkTokenValidity';
+import verifyAdminUser from './middlewares/checkIfUserIsAdmin';
+
+const router = Router();
+
+router.post(
+  '/',
+  validateRequest(createFixtureSchema, 'body'),
+  checkTokenValidity,
+  verifyAdminUser,
+  actions.create,
+);
+
+export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 
 import authRouter from './auth';
 import teamRouter from './team';
+import fixtureRouter from './fixture';
 
 const router = Router();
 
@@ -14,5 +15,6 @@ router.get('/', (req, res) =>
 
 router.use('/auth', authRouter);
 router.use('/teams', teamRouter);
+router.use('/fixtures', fixtureRouter);
 
 export default router;

--- a/src/routes/team.js
+++ b/src/routes/team.js
@@ -5,7 +5,7 @@ import validateRequest from './middlewares/validate-input';
 import {
   createTeamSchema,
   updateTeamSchema,
-  objectIdSchema,
+  teamIdSchema,
 } from './middlewares/joi-schema';
 import { checkTokenValidity } from './middlewares/checkTokenValidity';
 import verifyAdminUser from './middlewares/checkIfUserIsAdmin';
@@ -25,7 +25,7 @@ router.get('/', checkTokenValidity, actions.all);
 router.patch(
   '/:teamId',
   validateRequest(updateTeamSchema, 'body'),
-  validateRequest(objectIdSchema, 'params'),
+  validateRequest(teamIdSchema, 'params'),
   checkTokenValidity,
   verifyAdminUser,
   actions.update,
@@ -33,14 +33,14 @@ router.patch(
 
 router.get(
   '/:teamId',
-  validateRequest(objectIdSchema, 'params'),
+  validateRequest(teamIdSchema, 'params'),
   checkTokenValidity,
   actions.find,
 );
 
 router.delete(
   '/:teamId',
-  validateRequest(objectIdSchema, 'params'),
+  validateRequest(teamIdSchema, 'params'),
   checkTokenValidity,
   verifyAdminUser,
   actions.deleteOne,

--- a/src/tests/e2e/fixture.test.js
+++ b/src/tests/e2e/fixture.test.js
@@ -1,0 +1,140 @@
+import request from 'supertest';
+import mongoose from 'mongoose';
+
+import app from '../../server';
+
+import * as mocks from '../mocks/fixtures';
+import { mockUser, mockAdmin } from '../mocks/users';
+import { mockTeam1, mockTeam2 } from '../mocks/teams';
+
+import User from '../../db/models/User';
+import Fixture from '../../db/models/Fixture';
+import Team from '../../db/models/Team';
+
+import { generateToken } from '../../utils/helpers';
+
+const fixturesUrl = '/api/v1/fixtures';
+
+let userToken;
+let adminToken;
+
+beforeAll(async () => {
+  const users = await User.insertMany([mockAdmin, mockUser]);
+  await Team.insertMany([mockTeam1, mockTeam2]);
+  adminToken = await generateToken({ id: users[0]._id }, '5m');
+  userToken = await generateToken({ id: users[1]._id }, '5m');
+});
+
+afterAll(async done => {
+  await User.deleteMany({});
+  await Team.deleteMany({});
+  await Fixture.deleteMany({});
+  await mongoose.connection.close();
+  done();
+});
+
+describe('E2E Fixture creation', () => {
+  it('should throw an error when a token is not present in the request header', async () => {
+    const res = await request(app)
+      .post(fixturesUrl)
+      .send(mocks.mockFixture1);
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('Unauthorized user, please login');
+  });
+
+  it('should throw an error when the user making the request does not have admin rights', async () => {
+    const res = await request(app)
+      .post(fixturesUrl)
+      .set('authorization', `Bearer ${userToken}`)
+      .send(mocks.mockFixture1);
+    expect(res.status).toBe(403);
+  });
+
+  it('should create a fixture successfully when valid inputs are supplied', async () => {
+    const res = await request(app)
+      .post(fixturesUrl)
+      .set('authorization', `Bearer ${adminToken}`)
+      .send(mocks.mockFixture1);
+    expect(res.status).toBe(201);
+    expect(Object.keys(res.body.data).includes('referee')).toBeTruthy();
+    expect(Object.keys(res.body.data).includes('homeTeam')).toBeTruthy();
+    expect(Object.keys(res.body.data).includes('awayTeam')).toBeTruthy();
+    expect(Object.keys(res.body.data).includes('uniqueLink')).toBeTruthy();
+  });
+
+  it('should throw an error when the fixture is existing already', async () => {
+    const res = await request(app)
+      .post(fixturesUrl)
+      .set('authorization', `Bearer ${adminToken}`)
+      .send(mocks.mockFixture1);
+    expect(res.status).toBe(409);
+    expect(res.body.message).toBe('This Fixture exists already');
+  });
+
+  it('should throw an error when the fixture date is missing', async () => {
+    const res = await request(app)
+      .post(fixturesUrl)
+      .set('authorization', `Bearer ${adminToken}`)
+      .send(mocks.missingDate);
+    expect(res.status).toBe(422);
+    expect(res.body.error[0]).toBe('date is required');
+  });
+
+  it('should throw an error when referee name is missing', async () => {
+    const res = await request(app)
+      .post(fixturesUrl)
+      .set('authorization', `Bearer ${adminToken}`)
+      .send(mocks.missingReferee);
+    expect(res.status).toBe(422);
+    expect(res.body.error[0]).toBe('referee is required');
+  });
+
+  it('should throw an error when the awayTeamId is missing', async () => {
+    const res = await request(app)
+      .post(fixturesUrl)
+      .set('authorization', `Bearer ${adminToken}`)
+      .send(mocks.missingAwayTeam);
+    expect(res.status).toBe(422);
+    expect(res.body.error[0]).toBe('awayTeamId is required');
+  });
+
+  it('should throw an error when the homeTeamId is missing', async () => {
+    const res = await request(app)
+      .post(fixturesUrl)
+      .set('authorization', `Bearer ${adminToken}`)
+      .send(mocks.missingHomeTeam);
+    expect(res.status).toBe(422);
+    expect(res.body.error[0]).toBe('homeTeamId is required');
+  });
+
+  it('should throw an error when the date passed is later than the current date', async () => {
+    const res = await request(app)
+      .post(fixturesUrl)
+      .set('authorization', `Bearer ${adminToken}`)
+      .send(mocks.pastDate);
+    expect(res.status).toBe(422);
+    expect(res.body.error[0]).toBe('date must be later than or equal to today');
+  });
+
+  it('should throw an error when the homeTeamId is not tied to any existing team', async () => {
+    const res = await request(app)
+      .post(fixturesUrl)
+      .set('authorization', `Bearer ${adminToken}`)
+      .send({ ...mocks.mockFixture1, homeTeamId: '507f1f77bcf86cd799439011' });
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe(
+      'This team 507f1f77bcf86cd799439011 cannot be found',
+    );
+  });
+
+  it('should throw an error when the awayTeam is not tied to any existing team', async () => {
+    const res = await request(app)
+      .post(fixturesUrl)
+      .set('authorization', `Bearer ${adminToken}`)
+      .send({ ...mocks.mockFixture1, awayTeamId: '507f1f77bcf86cd799439011' });
+    expect(res.status).toBe(404);
+    expect(res.body.message).toBe(
+      'This team 507f1f77bcf86cd799439011 cannot be found',
+    );
+  });
+});

--- a/src/tests/e2e/team.test.js
+++ b/src/tests/e2e/team.test.js
@@ -260,8 +260,6 @@ describe('E2E Delete a team', () => {
       .delete(`${teamsUrl}/${team._id}`)
       .set('authorization', `Bearer ${adminToken}`);
 
-    console.log(res.body);
-
     expect(res.status).toBe(200);
     expect(res.body.message).toBe('Team Deleted');
   });

--- a/src/tests/mocks/fixtures.js
+++ b/src/tests/mocks/fixtures.js
@@ -5,7 +5,7 @@ import * as teams from './teams';
 
 export const mockFixture1 = {
   _id: '507f1f77bcf86cd799439016',
-  date: '2020-01-11T08:27:01.471Z',
+  date: '1-22-2020',
   homeTeamId: teams.mockTeam1._id,
   awayTeamId: teams.mockTeam2._id,
   referee: 'Phil Dowd',
@@ -16,11 +16,42 @@ export const mockFixture1 = {
 
 export const mockFixture2 = {
   _id: '507f1f77bcf86cd799439017',
-  date: '2020-01-11T08:27:01.471Z',
+  date: '1-22-2020',
   homeTeamId: teams.mockTeam2._id,
   awayTeamId: teams.mockTeam1._id,
   referee: 'Colina Pollins',
   status: 'PENDING',
   uniqueLink: faker.internet.url(),
   createdBy: mockAdmin._id,
+};
+
+export const missingDate = {
+  homeTeamId: teams.mockTeam2._id,
+  awayTeamId: teams.mockTeam1._id,
+  referee: 'Colina Pollins',
+};
+
+export const missingReferee = {
+  date: '1-22-2020',
+  homeTeamId: teams.mockTeam2._id,
+  awayTeamId: teams.mockTeam1._id,
+};
+
+export const missingHomeTeam = {
+  date: '1-22-2020',
+  awayTeamId: teams.mockTeam1._id,
+  referee: 'Colina Pollins',
+};
+
+export const missingAwayTeam = {
+  date: '1-22-2020',
+  homeTeamId: teams.mockTeam2._id,
+  referee: 'Colina Pollins',
+};
+
+export const pastDate = {
+  date: '1-22-2019',
+  homeTeamId: teams.mockTeam2._id,
+  awayTeamId: teams.mockTeam1._id,
+  referee: 'Colina Pollins',
 };

--- a/src/tests/models/fixture.test.js
+++ b/src/tests/models/fixture.test.js
@@ -34,7 +34,6 @@ describe('Unit tests for fixture model', () => {
     const fixtureCount = await Fixture.countDocuments();
 
     expect(fixtureCount).toEqual(2);
-    expect(new Date(newFixture.date).toISOString()).toEqual(mockFixture1.date);
     expect(newFixture.homeTeamId).toEqual(mockFixture1.homeTeamId);
     expect(newFixture.referee).toEqual(mockFixture1.referee);
     expect(newFixture.uniqueLink).toEqual(mockFixture1.uniqueLink);

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -4,6 +4,7 @@ import bcrypt from 'bcrypt';
 
 import User from '../db/models/User';
 import Team from '../db/models/Team';
+import Fixture from '../db/models/Fixture';
 
 dotenv.config();
 
@@ -96,8 +97,7 @@ export const generateToken = (payload, expiresIn = '30days') =>
 /**
  * Check if Team exists
  *
- * @param {String} name
- * @param {String} manager
+ * @param {Object} fields name, stadium, manager, id
  */
 export const checkIfTeamExists = async fields => {
   const team = Team.find();
@@ -114,3 +114,14 @@ export const checkIfTeamExists = async fields => {
  * @returns {Boolean} false if token is invalid
  */
 export const verifyToken = token => jwt.verify(token, process.env.SECRET_KEY);
+
+/**
+ * Check Fixture existence
+ *
+ * @param {Object} keys
+ * @returns {Object} if record exists
+ * @returns {null} if record does not exist
+ */
+export const checkIfFixtureExists = keys => Fixture.findOne({ ...keys });
+
+export const stripAllSpaces = words => words.replace(/\s/gi, '');


### PR DESCRIPTION
#### What does this PR do?
Implement create fixtures feature
#### Description of Task to be completed?
- [x] create route action for fixtures creation
- [x] create validators for route
- [x] write unit tests for the endpoint
#### How should this be manually tested?
- checkout to this branch
- make a `POST` request to the endpoint `/api/v1/fixtures` passing an object containing  the `homeTeamId`, `awayTeamId`, `referee` and the date fields.
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?(if applicable)
N/A
#### Screenshots
N/A