### PR TITLE
All Users can view pending and completed fixtures

### DIFF
--- a/src/routes/controllers/fixture.js
+++ b/src/routes/controllers/fixture.js
@@ -60,3 +60,18 @@ export const create = async (req, res) => {
     return helpers.serverError(res, error.message);
   }
 };
+
+export const all = async (req, res) => {
+  const { status } = req.query;
+
+  try {
+    const fixtures = await Fixture.find(
+      status && {
+        status: status.toUpperCase(),
+      },
+    );
+    return helpers.successResponse(res, 200, 'Fetched all fixtures', fixtures);
+  } catch (error) {
+    return helpers.serverError(res, error.message);
+  }
+};

--- a/src/routes/fixture.js
+++ b/src/routes/fixture.js
@@ -16,4 +16,6 @@ router.post(
   actions.create,
 );
 
+router.get('/', checkTokenValidity, actions.all);
+
 export default router;

--- a/src/tests/e2e/fixture.test.js
+++ b/src/tests/e2e/fixture.test.js
@@ -138,3 +138,77 @@ describe('E2E Fixture creation', () => {
     );
   });
 });
+
+describe('E2E Fetch all fixtures', () => {
+  it('should throw an error when a token is not present in the request header', async () => {
+    const res = await request(app).get(fixturesUrl);
+
+    expect(res.status).toBe(401);
+    expect(res.body.message).toBe('Unauthorized user, please login');
+  });
+
+  it('should fetch all fixtures', async () => {
+    await Fixture.insertMany([
+      {
+        date: '1-22-2020',
+        homeTeamId: mockTeam1._id,
+        awayTeamId: mockTeam2._id,
+        referee: 'Phil Dowd',
+        date: '1-23-2021',
+        status: 'PLAYED',
+        createdBy: mocks.mockFixture1.createdBy,
+        uniqueLink: Math.random(),
+      },
+      {
+        date: '1-22-2021',
+        homeTeamId: mockTeam2._id,
+        awayTeamId: mockTeam1._id,
+        referee: 'Phil Dowd',
+        date: '1-23-2022',
+        status: 'POSTPONED',
+        createdBy: mocks.mockFixture1.createdBy,
+        uniqueLink: Math.random(),
+      },
+    ]);
+
+    const res = await request(app)
+      .get(fixturesUrl)
+      .set('authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBeGreaterThan(0);
+  });
+
+  it('should only return pending fixtures when the query is passed', async () => {
+    const res = await request(app)
+      .get(fixturesUrl)
+      .query({ status: 'pending' })
+      .set('authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBeGreaterThan(0);
+    expect(res.body.data[0].status).toBe('PENDING');
+  });
+
+  it('should only return played fixtures when the query is passed', async () => {
+    const res = await request(app)
+      .get(fixturesUrl)
+      .query({ status: 'played' })
+      .set('authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBeGreaterThan(0);
+    expect(res.body.data[0].status).toBe('PLAYED');
+  });
+
+  it('should only return postponed fixtures when the query is passed', async () => {
+    const res = await request(app)
+      .get(fixturesUrl)
+      .query({ status: 'postponed' })
+      .set('authorization', `Bearer ${userToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.length).toBeGreaterThan(0);
+    expect(res.body.data[0].status).toBe('POSTPONED');
+  });
+});

--- a/src/tests/e2e/team.test.js
+++ b/src/tests/e2e/team.test.js
@@ -18,6 +18,7 @@ let adminToken;
 
 beforeAll(async () => {
   await Team.deleteMany({});
+  await User.deleteMany({});
   const users = await User.insertMany([mockAdmin, mockUser]);
   adminToken = await generateToken({ id: users[0]._id }, '5m');
   userToken = await generateToken({ id: users[1]._id }, '5m');


### PR DESCRIPTION
#### What does this PR do?
Implement view fixtures feature
#### Description of Task to be completed?
- [x] create route action for fixtures fetching
- [x] create validators for route
- [x] write unit tests for the endpoint
#### How should this be manually tested?
- checkout to this branch
- make a `GET` request to the endpoint `/api/v1/fixtures`. You can choose to pass a `status` query parameter to the request 
```javascript
/fixtures?status=pending OR /fixtures?status=played
```
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?(if applicable)
N/A
#### Screenshots
N/A