### PR TITLE
Admin users can update a fixture

### DIFF
--- a/src/routes/controllers/fixture.js
+++ b/src/routes/controllers/fixture.js
@@ -90,3 +90,24 @@ export const find = async (req, res) => {
     return helpers.serverError(res, error.message);
   }
 };
+
+export const update = async (req, res) => {
+  const { fixtureId } = req.params;
+
+  try {
+    const updatedFixture = await Fixture.findOneAndUpdate(
+      { _id: fixtureId },
+      { ...req.body },
+      { new: true },
+    );
+
+    return helpers.successResponse(res, 200, 'Fixture updated successfully', {
+      name: updatedFixture.name,
+      referee: updatedFixture.referee,
+      date: updatedFixture.date,
+    });
+  } catch (error) {
+    /* istanbul ignore next */
+    return helpers.serverError(res, error.message);
+  }
+};

--- a/src/routes/controllers/team.js
+++ b/src/routes/controllers/team.js
@@ -36,7 +36,7 @@ export const all = async (req, res) => {
 };
 
 export const update = async (req, res) => {
-  // This fields are not compulsory to be there but
+  // These fields are not compulsory to be there but
   // they better not be empty strings or unmatched types
   const { name, manager } = req.body;
   const { teamId } = req.params;

--- a/src/routes/fixture.js
+++ b/src/routes/fixture.js
@@ -1,10 +1,17 @@
 import { Router } from 'express';
 
+import Fixture from '../db/models/Fixture';
 import * as actions from './controllers/fixture';
+
 import validateRequest from './middlewares/validate-input';
-import { createFixtureSchema, fixtureIdSchema } from './middlewares/joi-schema';
+import {
+  createFixtureSchema,
+  fixtureIdSchema,
+  updateFixtureSchema,
+} from './middlewares/joi-schema';
 import { checkTokenValidity } from './middlewares/checkTokenValidity';
 import verifyAdminUser from './middlewares/checkIfUserIsAdmin';
+import { checkResourceOwner } from './middlewares/checkResourceOwner';
 
 const router = Router();
 
@@ -23,6 +30,16 @@ router.get(
   validateRequest(fixtureIdSchema, 'params'),
   checkTokenValidity,
   actions.find,
+);
+
+router.patch(
+  '/:fixtureId',
+  validateRequest(updateFixtureSchema, 'body'),
+  validateRequest(fixtureIdSchema, 'params'),
+  checkTokenValidity,
+  verifyAdminUser,
+  checkResourceOwner(Fixture, 'fixtureId'),
+  actions.update,
 );
 
 export default router;

--- a/src/routes/middlewares/checkResourceOwner.js
+++ b/src/routes/middlewares/checkResourceOwner.js
@@ -1,0 +1,22 @@
+import * as helpers from '../../utils/helpers';
+
+export const checkResourceOwner = (Model, key) => async (req, res, next) => {
+  const { params } = req;
+  const resource = await Model.findOne({ _id: params[key] });
+
+  if (!resource) {
+    return helpers.errorResponse(res, 404, 'This resource does not exist');
+  }
+
+  // check if the resource owner is the request user
+  if (String(resource.createdBy) !== String(req.user._id)) {
+    return helpers.errorResponse(
+      res,
+      403,
+      'You have been caught with your hands in the cookie jar, contact your admin',
+    );
+  }
+
+  req[Model.modelName.toLowerCase()] = resource;
+  next();
+};

--- a/src/routes/middlewares/joi-schema.js
+++ b/src/routes/middlewares/joi-schema.js
@@ -111,37 +111,39 @@ export const teamIdSchema = Joi.object()
   .options({ ...options });
 
 // Fixtures
+
+const fixtureDateSchema = Joi.date()
+  .min('now')
+  .error(errors => {
+    const [error] = errors;
+    const { type, context } = error;
+    if (type === 'any.required') {
+      return {
+        message: `${context.key} is required`,
+      };
+    }
+    if (type === 'any.empty') {
+      return {
+        message: `${context.key} is required`,
+      };
+    }
+
+    if (type === 'date.min') {
+      return {
+        message: `${context.key} must be later than or equal to today`,
+      };
+    }
+    if (type === 'date.base') {
+      return {
+        message: `${context.key} must be later than or equal to today`,
+      };
+    }
+    return `${context.key} must be a valid date type and must be greater than or equal to today`;
+  });
+
 export const createFixtureSchema = Joi.object()
   .keys({
-    date: Joi.date()
-      .min('now')
-      .required()
-      .error(errors => {
-        const [error] = errors;
-        const { type, context } = error;
-        if (type === 'any.required') {
-          return {
-            message: `${context.key} is required`,
-          };
-        }
-        if (type === 'any.empty') {
-          return {
-            message: `${context.key} is required`,
-          };
-        }
-
-        if (type === 'date.min') {
-          return {
-            message: `${context.key} must be later than or equal to today`,
-          };
-        }
-        if (type === 'date.base') {
-          return {
-            message: `${context.key} must be later than or equal to today`,
-          };
-        }
-        return `${context.key} must be a valid date type and must be greater than or equal to today`;
-      }),
+    date: fixtureDateSchema.required(),
     homeTeamId: objectIdSchema.required(),
     awayTeamId: objectIdSchema.required(),
     referee: alphabetsOnlySchema.min(4).required(),
@@ -151,5 +153,15 @@ export const createFixtureSchema = Joi.object()
 export const fixtureIdSchema = Joi.object()
   .keys({
     fixtureId: objectIdSchema.required(),
+  })
+  .options({ ...options });
+
+export const updateFixtureSchema = Joi.object()
+  .keys({
+    date: fixtureDateSchema,
+    referee: alphabetsOnlySchema.min(4),
+    status: stringSchema
+      .uppercase()
+      .valid(['PENDING', 'PLAYED', 'POSTPONED', 'CANCELLED']),
   })
   .options({ ...options });

--- a/src/tests/e2e/team.test.js
+++ b/src/tests/e2e/team.test.js
@@ -18,6 +18,7 @@ let adminToken;
 
 beforeAll(async () => {
   await User.deleteMany({});
+  await Team.deleteMany({});
   const users = await User.insertMany([mockAdmin, mockUser]);
   adminToken = await generateToken({ id: users[0]._id }, '5m');
   userToken = await generateToken({ id: users[1]._id }, '5m');
@@ -44,6 +45,8 @@ describe('E2E Team creation', () => {
       .post(teamsUrl)
       .set('authorization', `Bearer ${userToken}`)
       .send(mocks.mockTeam1);
+    console.log(res.body);
+
     expect(res.status).toBe(403);
   });
 

--- a/src/tests/mocks/users.js
+++ b/src/tests/mocks/users.js
@@ -1,5 +1,5 @@
 export const mockUser = {
-  _id: '507f1f77bcf86cd799439011',
+  _id: '5e1cf8621f0db217c38d7559',
   fullName: 'John Doe',
   email: 'john.doe@example.com',
   password: 'password',
@@ -7,7 +7,7 @@ export const mockUser = {
 };
 
 export const mockAdmin = {
-  _id: '507f1f77bcf86cd799439012',
+  _id: '5e1cf8659f0db217c38d7559',
   fullName: 'Jane Doe',
   email: 'jane.doe@example.com',
   password: 'password',


### PR DESCRIPTION
#### What does this PR do?
Implement view a update a fixture feature
#### Description of Task to be completed?
- [x] create route action for fixtures updating a fixture
- [x] create validators for route
- [x] write unit tests for the endpoint
#### How should this be manually tested?
- checkout to this branch
- create or get an existing fixture from your database
- make a `PATCH` request to the endpoint `/api/v1/fixtures/fixtureid-from-your-database`. You can only update the `referee` and `date` of the fixture.
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?(if applicable)
N/A
#### Screenshots
N/A