### PR TITLE
Admin users can delete fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged",
-      "pre-push": "npm run test:coverage"
+      "pre-push": "npm test"
     }
   },
   "lint-staged": {
@@ -32,7 +32,6 @@
     "check-staged": "lint-staged",
     "prettier": "prettier --write '**/*.{js,jsx}'",
     "test": "NODE_ENV=test jest",
-    "test:coverage": "NODE_ENV=test jest --coverage",
     "test:watch": "NODE_ENV=test jest --watch",
     "build": "rm -rf build && babel src -d build",
     "lint": "eslint src --fix"

--- a/src/routes/controllers/fixture.js
+++ b/src/routes/controllers/fixture.js
@@ -111,3 +111,19 @@ export const update = async (req, res) => {
     return helpers.serverError(res, error.message);
   }
 };
+
+export const deleteOne = async (req, res) => {
+  const { fixtureId } = req.params;
+
+  try {
+    const deletedFixture = await Fixture.findByIdAndDelete({ _id: fixtureId });
+    if (deletedFixture) {
+      return helpers.successResponse(res, 200, 'Fixture Deleted');
+    }
+    /* istanbul ignore next */
+    throw Error('What could ever happen here anyways?');
+  } catch (error) {
+    /* istanbul ignore next */
+    return helpers.serverError(res, error.message);
+  }
+};

--- a/src/routes/fixture.js
+++ b/src/routes/fixture.js
@@ -42,4 +42,13 @@ router.patch(
   actions.update,
 );
 
+router.delete(
+  '/:fixtureId',
+  validateRequest(fixtureIdSchema, 'params'),
+  checkTokenValidity,
+  verifyAdminUser,
+  checkResourceOwner(Fixture, 'fixtureId'),
+  actions.deleteOne,
+);
+
 export default router;

--- a/src/tests/e2e/auth.test.js
+++ b/src/tests/e2e/auth.test.js
@@ -24,6 +24,7 @@ describe('E2E User registration', () => {
     const res = await request(app)
       .post(signupUrl)
       .send(mocks.mockUser);
+
     expect(res.status).toBe(201);
     expect(Object.keys(res.body.data).includes('token')).toBeTruthy();
     expect(res.body.data.token).not.toBe('');

--- a/src/tests/e2e/team.test.js
+++ b/src/tests/e2e/team.test.js
@@ -17,11 +17,13 @@ let userToken;
 let adminToken;
 
 beforeAll(async () => {
+  console.log('I got here');
+
   await User.deleteMany({});
   await Team.deleteMany({});
   const users = await User.insertMany([mockAdmin, mockUser]);
-  adminToken = await generateToken({ id: users[0]._id }, '5m');
-  userToken = await generateToken({ id: users[1]._id }, '5m');
+  adminToken = await generateToken({ id: users[0]._id }, '1h');
+  userToken = await generateToken({ id: users[1]._id }, '1h');
 });
 
 afterAll(async done => {
@@ -45,7 +47,6 @@ describe('E2E Team creation', () => {
       .post(teamsUrl)
       .set('authorization', `Bearer ${userToken}`)
       .send(mocks.mockTeam1);
-    console.log(res.body);
 
     expect(res.status).toBe(403);
   });
@@ -134,6 +135,8 @@ describe('E2E Team Update', () => {
 
   it('should throw an error when a token is not present in the request header', async () => {
     team = await Team.findOne();
+    console.log(team, 'update team');
+
     const res = await request(app)
       .patch(`${teamsUrl}/${team._id}`)
       .send(updateBody);
@@ -215,6 +218,7 @@ describe('E2E Fetch a single team', () => {
   let team;
   it('should throw an error when a token is not present in the request header', async () => {
     team = await Team.findOne();
+    console.log(team, 'get one');
     const res = await request(app).get(`${teamsUrl}/${team._id}`);
 
     expect(res.status).toBe(401);
@@ -252,6 +256,8 @@ describe('E2E Delete a team', () => {
   let team;
   it('should throw an error when a token is not present in the request header', async () => {
     team = await Team.findOne();
+    console.log(team, 'delete');
+
     const res = await request(app).delete(`${teamsUrl}/${team._id}`);
 
     expect(res.status).toBe(401);


### PR DESCRIPTION
#### What does this PR do?
Implement Admin users can delete fixtures feature
#### Description of Task to be completed?
- [x] create route action for fixtures deleting fixtures
- [x] create validators for route
- [x] write unit tests for the endpoint
#### How should this be manually tested?
- checkout to this branch
- get a fixture from your database
- make a `DELETE` request to the endpoint `/api/v1/fixtures/fixture-id-from-your-database`
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?(if applicable)
N/A
#### Screenshots
N/A